### PR TITLE
Add mechanism to return errors from signing delegate method

### DIFF
--- a/Sources/APIAdapter.swift
+++ b/Sources/APIAdapter.swift
@@ -33,7 +33,7 @@ public protocol APIAdapterDelegate: class {
     ///
     /// The `authorization` property of `APIEndpoint` is provided for manual checking whether the
     /// request should be signed, because signing non-authorized endpoints might pose as a security risk.
-    func apiAdapter(_ apiAdapter: APIAdapter, willRequest request: URLRequest, to endpoint: APIEndpoint, completion: @escaping (URLRequest) -> Void)
+    func apiAdapter(_ apiAdapter: APIAdapter, willRequest request: URLRequest, to endpoint: APIEndpoint, completion: @escaping (APIResult<URLRequest>) -> Void)
 }
 
 /// Protocol describing interface communicating with API resources (most probably over internet).
@@ -134,8 +134,13 @@ public final class URLSessionAPIAdapter: APIAdapter {
         }
 
         if let delegate = delegate {
-            delegate.apiAdapter(self, willRequest: request, to: endpoint) { request in
-                self.send(request: request, completion: completion)
+            delegate.apiAdapter(self, willRequest: request, to: endpoint) { result in
+                switch result {
+                case .value(let request):
+                    self.send(request: request, completion: completion)
+                case .error(let error):
+                    completion(.error(error))
+                }
             }
         } else {
             send(request: request, completion: completion)

--- a/Tests/FTAPIKitTests/Mockups/MockupAPIAdapterDelegate.swift
+++ b/Tests/FTAPIKitTests/Mockups/MockupAPIAdapterDelegate.swift
@@ -10,13 +10,13 @@ import FTAPIKit
 import Foundation
 
 final class MockupAPIAdapterDelegate: APIAdapterDelegate {
-    func apiAdapter(_ apiAdapter: APIAdapter, willRequest request: URLRequest, to endpoint: APIEndpoint, completion: @escaping (URLRequest) -> Void) {
+    func apiAdapter(_ apiAdapter: APIAdapter, willRequest request: URLRequest, to endpoint: APIEndpoint, completion: @escaping (APIResult<URLRequest>) -> Void) {
         if endpoint.authorized {
             var newRequest = request
             newRequest.addValue("Bearer " + UUID().uuidString, forHTTPHeaderField: "Authorization")
-            completion(newRequest)
+            completion(.value(newRequest))
         } else {
-            completion(request)
+            completion(.value(request))
         }
     }
 


### PR DESCRIPTION
If signing was executed asynchronously there was no mechanism to return errors back. Signing can by definition fail, so this enables this functionality.