### PR TITLE
Send finished completion from endpoint subscription

### DIFF
--- a/Sources/FTAPIKit/Combine/EndpointSubscription.swift
+++ b/Sources/FTAPIKit/Combine/EndpointSubscription.swift
@@ -23,6 +23,7 @@ final class EndpointSubscription<S: Subscriber, R, E>: Subscription where S.Inpu
             switch result {
             case .success(let input):
                 _ = subscriber?.receive(input)
+                subscriber?.receive(completion: .finished)
             case .failure(let error):
                 subscriber?.receive(completion: .failure(error))
             }


### PR DESCRIPTION
EndpointSubscriber never returned finished completion. This might lead to unexpected behavior for the user of the library.