### PR TITLE
Make `percentEncoded` computed property public

### DIFF
--- a/Sources/FTAPIKit/URLQuery.swift
+++ b/Sources/FTAPIKit/URLQuery.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 public struct URLQuery: ExpressibleByDictionaryLiteral {
-    private let items: [URLQueryItem]
+    public let items: [URLQueryItem]
 
     init() {
         self.items = []

--- a/Sources/FTAPIKit/URLQuery.swift
+++ b/Sources/FTAPIKit/URLQuery.swift
@@ -21,7 +21,7 @@ public struct URLQuery: ExpressibleByDictionaryLiteral {
         return URLQueryItem(name: encodedName, value: encodedValue)
     }
 
-    var percentEncoded: String? {
+    public var percentEncoded: String? {
         guard !items.isEmpty else {
             return nil
         }


### PR DESCRIPTION
In some situation it is needed to have `percentEncoded` as a public property in order to have an easy access to the query items.
I would consider to make `items` public as well