### PR TITLE
Release 1.2.3

### DIFF
--- a/FTAPIKit.podspec
+++ b/FTAPIKit.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name                        = "FTAPIKit"
-  s.version                     = "1.2.2"
+  s.version                     = "1.2.3"
   s.summary                     = "Declarative, generic and protocol-oriented REST API framework using URLSession and Codable"
   s.description                 = <<-DESC
     Protocol-oriented framework for communication with REST APIs.

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ When using Swift package manager install using Xcode 11+
 or add following line to your dependencies:
 
 ```swift
-.package(url: "https://github.com/futuredapp/FTAPIKit.git", from: "1.2.2")
+.package(url: "https://github.com/futuredapp/FTAPIKit.git", from: "1.2.3")
 ```
 
 When using CocoaPods add following line to your `Podfile`:


### PR DESCRIPTION
URLQuery has now public items and encoding property, so it can be used in custom request builders.