### PR TITLE
Async/await support

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -1,5 +1,11 @@
 disabled_rules:
   - line_length
+  # Combination of SwiftLint 0.43.1 and Xcode 12.5.1
+  # warns about false positives for this rule
+  - empty_xctest_method
+  # Type inference of `await try` methods
+  # does not work well in Xcode 13 Beta
+  - implicit_return
 excluded:
   - Pods
   - .build

--- a/Sources/FTAPIKit/URLServer+Async.swift
+++ b/Sources/FTAPIKit/URLServer+Async.swift
@@ -1,0 +1,45 @@
+#if swift(>=5.5)
+import Foundation
+
+@available(macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0, *)
+public extension URLServer {
+    func call(endpoint: Endpoint) async throws {
+        return try await withCheckedThrowingContinuation { continuation in
+            call(endpoint: endpoint) { result in
+                switch result {
+                case .success:
+                    continuation.resume()
+                case .failure(let error):
+                    continuation.resume(throwing: error)
+                }
+            }
+        }
+    }
+
+    func call(data endpoint: Endpoint) async throws -> Data {
+        return try await withCheckedThrowingContinuation { continuation in
+            call(data: endpoint) { result in
+                switch result {
+                case .success(let data):
+                    continuation.resume(returning: data)
+                case .failure(let error):
+                    continuation.resume(throwing: error)
+                }
+            }
+        }
+    }
+
+    func call<EP: ResponseEndpoint>(response endpoint: EP) async throws -> EP.Response {
+        return try await withCheckedThrowingContinuation { continuation in
+            call(response: endpoint) { result in
+                switch result {
+                case .success(let response):
+                    continuation.resume(returning: response)
+                case .failure(let error):
+                    continuation.resume(throwing: error)
+                }
+            }
+        }
+    }
+}
+#endif

--- a/Tests/FTAPIKitTests/AsyncTests.swift
+++ b/Tests/FTAPIKitTests/AsyncTests.swift
@@ -1,0 +1,36 @@
+#if swift(>=5.5)
+import Foundation
+import XCTest
+
+final class AsyncTests: XCTestCase {
+    func testCallWithoutResponse() async throws {
+        guard #available(macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0, *) else {
+            return
+        }
+        let server = HTTPBinServer()
+        let endpoint = GetEndpoint()
+        try await server.call(endpoint: endpoint)
+    }
+
+    func testCallWithData() async throws {
+        guard #available(macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0, *) else {
+            return
+        }
+        let server = HTTPBinServer()
+        let endpoint = GetEndpoint()
+        let data = try await server.call(data: endpoint)
+        XCTAssertGreaterThan(data.count, 0)
+    }
+
+    func testCallParsingResponse() async throws {
+        guard #available(macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0, *) else {
+            return
+        }
+        let server = HTTPBinServer()
+        let user = User(uuid: UUID(), name: "Some Name", age: .random(in: 0...120))
+        let endpoint = UpdateUserEndpoint(request: user)
+        let response = try await server.call(response: endpoint)
+        XCTAssertEqual(user, response.json)
+    }
+}
+#endif


### PR DESCRIPTION
Add extension with async/await support for Swift 5.5.

Closes #72.