### PR TITLE
Use POSIX call to get page size or fallback

### DIFF
--- a/Sources/FTAPIKit/OutputStream+Write.swift
+++ b/Sources/FTAPIKit/OutputStream+Write.swift
@@ -5,7 +5,7 @@ import os
 
 extension OutputStream {
     private static let streamBufferSize = memoryPageSize()
-    
+
     /// We want our buffer to be as close to page size as possible. Therefore we use
     /// POSIX API to get pagesize. The alternative is using compiler private macro which
     /// is less explicit.

--- a/Sources/FTAPIKit/OutputStream+Write.swift
+++ b/Sources/FTAPIKit/OutputStream+Write.swift
@@ -18,6 +18,7 @@ extension OutputStream {
         return 4_096
         #endif
     }
+
     func write(inputStream: InputStream) throws {
         inputStream.open()
         defer { inputStream.close() }

--- a/Sources/FTAPIKit/OutputStream+Write.swift
+++ b/Sources/FTAPIKit/OutputStream+Write.swift
@@ -1,7 +1,22 @@
 import Foundation
 
+
+// We want our buffer to be as close to page size as possible. Therefore we use
+// POSIX API to get pagesize. The alternative is using compiler private macro which
+// is less explicit.
+//
+// In case os can't be imported from some reason, fallback to 4 KiB size.
+#if canImport(os)
+import os
+
+private func memoryPageSize() -> Int { Int(getpagesize()) }
+#else
+private func memoryPageSize() -> Int { 4_096 }
+#endif
+
+
 extension OutputStream {
-    private static let streamBufferSize = 4_096
+    private static let streamBufferSize = memoryPageSize()
 
     func write(inputStream: InputStream) throws {
         inputStream.open()

--- a/Sources/FTAPIKit/OutputStream+Write.swift
+++ b/Sources/FTAPIKit/OutputStream+Write.swift
@@ -1,23 +1,23 @@
 import Foundation
-
-
-// We want our buffer to be as close to page size as possible. Therefore we use
-// POSIX API to get pagesize. The alternative is using compiler private macro which
-// is less explicit.
-//
-// In case os can't be imported from some reason, fallback to 4 KiB size.
 #if canImport(os)
 import os
-
-private func memoryPageSize() -> Int { Int(getpagesize()) }
-#else
-private func memoryPageSize() -> Int { 4_096 }
 #endif
-
 
 extension OutputStream {
     private static let streamBufferSize = memoryPageSize()
-
+    
+    /// We want our buffer to be as close to page size as possible. Therefore we use
+    /// POSIX API to get pagesize. The alternative is using compiler private macro which
+    /// is less explicit.
+    ///
+    /// In case os can't be imported from some reason, fallback to 4 KiB size.
+    private static func memoryPageSize() -> Int {
+        #if canImport(os)
+        return Int(getpagesize())
+        #else
+        return 4_096
+        #endif
+    }
     func write(inputStream: InputStream) throws {
         inputStream.open()
         defer { inputStream.close() }


### PR DESCRIPTION
The original decision for using 4096 bytes wide buffer size were based on assumption, that memory page is 4096 bytes in size which is a good guess.

I have found out, that modern ARM platforms use 16 KiB pages.

https://developer.apple.com/forums/thread/47532