### PR TITLE
Remove Encoding dependency on URLRequest

### DIFF
--- a/Sources/FTAPIKit/Coding.swift
+++ b/Sources/FTAPIKit/Coding.swift
@@ -12,9 +12,6 @@ public protocol Encoding {
 
     /// Encodes the argument
     func encode<T: Encodable>(_ object: T) throws -> Data
-
-    /// Configures the request with proper headers etc., such as `Content-Type`.
-    func configure(request: inout URLRequest) throws
 }
 
 /// Protocol which enables use of any decoder using type-erasure.
@@ -22,8 +19,14 @@ public protocol Decoding {
     func decode<T: Decodable>(data: Data) throws -> T
 }
 
+/// Protocol extending types conforming to encoding
+public protocol URLRequestEncoding: Encoding {
+    /// Can configure the request with proper headers such as `Content-Type`.
+    func configure(request: inout URLRequest) throws
+}
+
 /// Type-erased JSON encoder for use with types conforming to `Server` protocol.
-public struct JSONEncoding: Encoding {
+public struct JSONEncoding: URLRequestEncoding {
     private let encoder: JSONEncoder
 
     public init(encoder: JSONEncoder = .init()) {

--- a/Sources/FTAPIKit/URLRequestBuilder.swift
+++ b/Sources/FTAPIKit/URLRequestBuilder.swift
@@ -41,7 +41,8 @@ struct URLRequestBuilder<S: URLServer> {
         case let endpoint as DataEndpoint:
             request.httpBody = endpoint.body
         case let endpoint as EncodableEndpoint:
-            try server.encoding.configure(request: &request)
+            let requestEncoding = server.encoding as? URLRequestEncoding
+            try requestEncoding?.configure(request: &request)
             request.httpBody = try endpoint.body(encoding: server.encoding)
         case let endpoint as URLEncodedEndpoint:
             request.setValue("application/x-www-form-urlencoded", forHTTPHeaderField: "Content-Type")


### PR DESCRIPTION
`Encoding` protocol has dependency on `URLRequest` even though it should be more general – to fulfill the abstract requirements defined by `Server` protocol.

Close #84.