### PR TITLE
Make async methods available on backportable systems

### DIFF
--- a/.github/workflows/macos-10.15.yml
+++ b/.github/workflows/macos-10.15.yml
@@ -1,0 +1,28 @@
+name: macOS 10.15
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - '*'
+
+jobs:
+  test:
+    runs-on: macos-10.15
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Lint
+      run: |
+        swiftlint --strict
+    - name: Pod lib lint
+      run: |
+        gem install bundler
+        bundle install --jobs 4 --retry 3
+        bundle exec pod lib lint --allow-warnings
+    - name: Swift build & test
+      run: |
+        swift build
+        swift test

--- a/.github/workflows/macos-11.yml
+++ b/.github/workflows/macos-11.yml
@@ -14,6 +14,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
+    - name: Setup Xcode version
+      uses: maxim-lobanov/setup-xcode@v1.4.0
+      with:
+        xcode-version: 13.1
     - name: Lint
       run: |
         swiftlint --strict

--- a/.github/workflows/macos-11.yml
+++ b/.github/workflows/macos-11.yml
@@ -1,4 +1,4 @@
-name: Test  – macOS
+name: macOS 11
 
 on:
   push:
@@ -10,7 +10,7 @@ on:
 
 jobs:
   test:
-    runs-on: macos-latest
+    runs-on: macos-11
 
     steps:
     - uses: actions/checkout@v2

--- a/Sources/FTAPIKit/URLServer+Async.swift
+++ b/Sources/FTAPIKit/URLServer+Async.swift
@@ -70,7 +70,7 @@ public extension URLServer {
 
 // Support of async-await for Xcode 13 and 13.1.
 #elseif swift(>=5.5)
-@available(macOS 11, iOS 15, watchOS 8, tvOS 15, *)
+@available(macOS 12, iOS 15, watchOS 8, tvOS 15, *)
 public extension URLServer {
 
     /// Performs call to endpoint which does not return any data in the HTTP response.

--- a/Sources/FTAPIKit/URLServer+Async.swift
+++ b/Sources/FTAPIKit/URLServer+Async.swift
@@ -1,7 +1,7 @@
 #if swift(>=5.5)
 import Foundation
 
-@available(macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0, *)
+@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
 public extension URLServer {
 
     /// Performs call to endpoint which does not return any data in the HTTP response.

--- a/Sources/FTAPIKit/URLServer+Async.swift
+++ b/Sources/FTAPIKit/URLServer+Async.swift
@@ -1,7 +1,76 @@
-#if swift(>=5.5)
 import Foundation
 
-@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
+// This extension is duplicated to support Xcode 13.0 and Xcode 13.1,
+// where backported concurrency is not available.
+
+// Support of async-await for Xcode 13.2+.
+#if swift(>=5.5.2)
+@available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
+public extension URLServer {
+
+    /// Performs call to endpoint which does not return any data in the HTTP response.
+    /// - Note: This call maps ``call(endpoint:completion:)`` to the async/await API
+    /// - Parameters:
+    ///   - endpoint: The endpoint
+    /// - Throws: Throws in case that result is .failure
+    /// - Returns: Void on success
+    func call(endpoint: Endpoint) async throws {
+        return try await withCheckedThrowingContinuation { continuation in
+            call(endpoint: endpoint) { result in
+                switch result {
+                case .success:
+                    continuation.resume()
+                case .failure(let error):
+                    continuation.resume(throwing: error)
+                }
+            }
+        }
+    }
+
+    /// Performs call to endpoint which returns an arbitrary data in the HTTP response, that should not be parsed by the decoder of the
+    /// server.
+    /// - Note: This call maps ``call(data:completion:)`` to the async/await API
+    /// - Parameters:
+    ///   - endpoint: The endpoint
+    /// - Throws: Throws in case that result is .failure
+    /// - Returns: Plain data returned with the HTTP Response
+    func call(data endpoint: Endpoint) async throws -> Data {
+        return try await withCheckedThrowingContinuation { continuation in
+            call(data: endpoint) { result in
+                switch result {
+                case .success(let data):
+                    continuation.resume(returning: data)
+                case .failure(let error):
+                    continuation.resume(throwing: error)
+                }
+            }
+        }
+    }
+
+    /// Performs call to endpoint which returns data that are supposed to be parsed by the decoder of the instance
+    /// conforming to ``Server`` in the HTTP response.
+    /// - Note: This call maps  ``call(response:completion:)`` to the async/await API
+    /// - Parameters:
+    ///   - endpoint: The endpoint
+    /// - Throws: Throws in case that result is .failure
+    /// - Returns: Instance of the required type
+    func call<EP: ResponseEndpoint>(response endpoint: EP) async throws -> EP.Response {
+        return try await withCheckedThrowingContinuation { continuation in
+            call(response: endpoint) { result in
+                switch result {
+                case .success(let response):
+                    continuation.resume(returning: response)
+                case .failure(let error):
+                    continuation.resume(throwing: error)
+                }
+            }
+        }
+    }
+}
+
+// Support of async-await for Xcode 13 and 13.1.
+#elseif swift(>=5.5)
+@available(macOS 11, iOS 15, watchOS 8, tvOS 15, *)
 public extension URLServer {
 
     /// Performs call to endpoint which does not return any data in the HTTP response.

--- a/Tests/FTAPIKitTests/AsyncTests.swift
+++ b/Tests/FTAPIKitTests/AsyncTests.swift
@@ -2,7 +2,7 @@
 import Foundation
 import XCTest
 
-@available(macOS 11, iOS 15, watchOS 8, tvOS 15, *)
+@available(macOS 12, iOS 15, watchOS 8, tvOS 15, *)
 final class AsyncTests: XCTestCase {
     func testCallWithoutResponse() async throws {
         let server = HTTPBinServer()

--- a/Tests/FTAPIKitTests/AsyncTests.swift
+++ b/Tests/FTAPIKitTests/AsyncTests.swift
@@ -2,7 +2,7 @@
 import Foundation
 import XCTest
 
-@available(macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0, *)
+@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
 final class AsyncTests: XCTestCase {
     func testCallWithoutResponse() async throws {
         let server = HTTPBinServer()

--- a/Tests/FTAPIKitTests/AsyncTests.swift
+++ b/Tests/FTAPIKitTests/AsyncTests.swift
@@ -2,7 +2,7 @@
 import Foundation
 import XCTest
 
-@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
+@available(macOS 11, iOS 15, watchOS 8, tvOS 15, *)
 final class AsyncTests: XCTestCase {
     func testCallWithoutResponse() async throws {
         let server = HTTPBinServer()


### PR DESCRIPTION
Ready for Xcode 13.2 support of async-await on older systems. It's done by duplicating the async extension on `URLServer`. I could not find better way to make it work in both in Xcode 13.2 and Xcode 13.1.

We should drop support for Xcode 13.0 and 13.1 when Xcode 13.2+ is fully available.