### PR TITLE
Change static var to static let constants

### DIFF
--- a/Sources/FTAPIKit/APIError+Standard.swift
+++ b/Sources/FTAPIKit/APIError+Standard.swift
@@ -41,5 +41,5 @@ public enum APIErrorStandard: APIError {
         }
     }
 
-    public static var unhandled: Standard = .unhandled(data: nil, response: nil, error: nil)
+    public static let unhandled: Standard = .unhandled(data: nil, response: nil, error: nil)
 }

--- a/Tests/FTAPIKitTests/AsyncTests.swift
+++ b/Tests/FTAPIKitTests/AsyncTests.swift
@@ -25,7 +25,7 @@ final class AsyncTests: XCTestCase {
         XCTAssertEqual(user, response.json)
     }
 
-    static var allTests = [
+    static let allTests = [
         ("testCallWithoutResponse", testCallWithoutResponse),
         ("testCallWithData", testCallWithData),
         ("testCallParsingResponse", testCallParsingResponse)

--- a/Tests/FTAPIKitTests/Mockups/Errors.swift
+++ b/Tests/FTAPIKitTests/Mockups/Errors.swift
@@ -12,5 +12,5 @@ struct ThrowawayAPIError: APIError {
         self.init()
     }
 
-    static var unhandled = Self()
+    static let unhandled = Self()
 }

--- a/Tests/FTAPIKitTests/ResponseTests.swift
+++ b/Tests/FTAPIKitTests/ResponseTests.swift
@@ -219,7 +219,7 @@ final class ResponseTests: XCTestCase {
         wait(for: [expectation], timeout: timeout)
     }
 
-    static var allTests = [
+    static let allTests = [
         ("testGet", testGet),
         ("testClientError", testClientError),
         ("testServerError", testServerError),

--- a/Tests/FTAPIKitTests/URLQueryTests.swift
+++ b/Tests/FTAPIKitTests/URLQueryTests.swift
@@ -38,7 +38,7 @@ final class URLQueryTests: XCTestCase {
         XCTAssertEqual(query.percentEncoded, "a=&b=")
     }
 
-    static var allTests = [
+    static let allTests = [
         ("testSpaceEncoding", testSpaceEncoding),
         ("testDelimitersEncoding", testDelimitersEncoding),
         ("testQueryAppending", testQueryAppending),


### PR DESCRIPTION
There were some shared variables, which were `static var`. This can result in mutation of these constants, which is definitely not on purpose and could result in an undefined behavior.